### PR TITLE
[Privacy] Anonymize IP address in Google Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-50123418-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>-->
 


### PR DESCRIPTION
This change will request that Google mask the last octet of the IP address in memory before performing further processing.
https://support.google.com/analytics/answer/2763052?hl=en